### PR TITLE
Added APIE link.

### DIFF
--- a/config/default-example.yaml
+++ b/config/default-example.yaml
@@ -51,6 +51,7 @@ conniebot:
     **About these conversions**
     <https://en.wikipedia.org/wiki/X-SAMPA>
     <https://web.archive.org/web/20191116002807/http://kneequickie.com/kq/Z-SAMPA>
+    <https://gist.github.com/xsduan/8ebd580be71214c57aa554ec9050916c>
 
     found a bug or want to suggest a feature?
     github: <https://github.com/xsduan/conniebot>


### PR DESCRIPTION
There is no APIE link and many people have been confused by that. I only now found out about the APIE notation and found a link explaining it at least a bit. That's why I propose adding the link to this.